### PR TITLE
HTML Report: fixed error stack trace

### DIFF
--- a/lib/nightwatch-runner.js
+++ b/lib/nightwatch-runner.js
@@ -113,7 +113,10 @@ function patchNighwatchAsyncTree () {
           if (!lastResult || !lastResult.failure) {
             yield * cucumber.logPassedStep(node.step)
           } else {
-            yield * cucumber.logFailedStep(node.step, lastResult.message + '\n' + lastResult.stacktrace, client.terminated)
+            yield * cucumber.logFailedStep(node.step,
+              lastResult.message + '\n' +
+              lastResult.failure + '\n' +
+              lastResult.stackTrace, client.terminated)
           }
         }
       }).then(done).catch(done)


### PR DESCRIPTION
I have some problem with nightwatch runner. Problem is deficient error output. 
There is no problem if i use a cucumber runner.

Here is an example:

```
Failures:

1) Scenario: Some scenario - features/some.feature:18
   Step: Given anything - features/some.feature:18:11
   Step Definition: ../../../src/__e2e__/step_definitions/some.js:3
   Message:
     Any error message .....
     undefined
```

Expected behaviour:
```
 ✖ Any error message .....  - expected "0" but got: "error"
    at Object.<anonymous> (../../../src/__e2e__/step_definitions/some.js:9:7)
    at undefined.next (native)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```  
"Undefined" was also appeared in report instead of stackTrace

In addition to fix this problem I have also added full description of error in report. (for example: - expected "0" but got: "error").