### PR TITLE
add junit report format

### DIFF
--- a/lib/cucumber-api.js
+++ b/lib/cucumber-api.js
@@ -8,6 +8,7 @@ const mkdirp = pify(require('mkdirp'))
 const open = require('open')
 const peerRequire = require('./peer-require')
 const cucumberHtmlReport = require('./cucumber-html-report')
+const cucumberJunitReport = require('./cucumber-junit-report')
 const Cucumber = peerRequire('cucumber/lib/cucumber')
 
 tmp.setGracefulCleanup()
@@ -115,4 +116,13 @@ module.exports = class CucumberAPI {
       }
     }
   }
+
+  * createCucumberJunitReport (options) {
+    const report = JSON.parse(yield fs.readFile(options.jsonReport))
+
+    if (options.junitReport) {
+      cucumberJunitReport(options.junitReport, report)
+    }
+  }
+
 }

--- a/lib/cucumber-junit-report.js
+++ b/lib/cucumber-junit-report.js
@@ -1,0 +1,83 @@
+'use strict'
+
+const path = require('path')
+const _ = require('lodash')
+const mkdirp = require('mkdirp')
+const builder = require('junit-report-builder')
+
+function writeReport (options, featureOutput) {
+  // copy data
+  const features = _.cloneDeep(featureOutput)
+  // loop over features
+  features.forEach(function (feature) {
+    // create new feature
+    const suite = builder
+                    .testSuite()
+                    .name(options.suiteNamePrefix + feature.name)
+
+    // quit here if feature is empty
+    if (!feature.elements) { return }
+    // loop over scenarios
+    feature.elements.forEach(function (scenario) {
+      let result = false
+      const messages = []
+      // loop over steps
+      scenario.steps.forEach(function (step) {
+        // quit if steps are empty
+        if (step.result) {
+          // on failure
+          if (step.result.status === 'failed') {
+            result = 'failure'
+            messages.push('Failed Step: ' + step.keyword + step.name +
+              '\nMessage: ' + step.result.error_message +
+              '\nWhere: ' + step.match.location)
+          }
+          // on undefined
+          // only output skipped if no error occurred in scenario
+          if (step.result.status === 'undefined') {
+            if (!result) { result = 'skipped' }
+          }
+        }
+      })
+
+      const testCase = suite.testCase()
+        .className(options.classNamePrefix + feature.name)
+        .name(options.scenarioNamePrefix + scenario.name)
+
+      // create scenario output
+      switch (result) {
+        // if at least one step was skipped and no failures occurred
+        case 'skipped':
+          // mark as skipped
+          testCase
+            .skipped()
+          break
+        // if at least one step failed
+        case 'failure':
+          // mark as failure and output failure messages
+          testCase
+            .failure(messages.join('\n\n'))
+          break
+        // if a scenario runs without any failed or skipped steps
+        default:
+          // successful tests are already handled
+      }
+    })
+  })
+
+  // persistent data
+  builder.writeTo(options.file)
+}
+
+function generateReport (junitOptions, featureOutput) {
+  const options = _.defaults(junitOptions, {
+    classNamePrefix: 'Feature: ',
+    suiteNamePrefix: 'Feature: ',
+    scenarioNamePrefix: 'Scenario: '
+  })
+
+  mkdirp.sync(path.dirname(options.file))
+  writeReport(options, featureOutput)
+}
+
+module.exports = generateReport

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,9 @@ module.exports = function (providedOptions) {
     supportFiles: [],
     jsonReport: 'reports/cucumber.json',
     htmlReport: 'reports/cucumber.html',
+    junitReport: {
+      file: 'reports/junit.xml'
+    },
     openReport: false,
     stepTimeout: 30000
   }, providedOptions)

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -86,6 +86,7 @@ module.exports = class Runner {
 
     if (!this.nightwatchApi.isRunningInParallel()) {
       yield * this.cucumberApi.createCucumberHtmlReport(this.options)
+      yield * this.cucumberApi.createCucumberJunitReport(this.options)
     }
 
     return success
@@ -111,6 +112,7 @@ module.exports = class Runner {
       const reports = yield pify(glob)(self.addIndexToFileName(self.options.jsonReport, '*'))
       yield * self.cucumberApi.mergeCucumberJsonReports(reports, self.options.jsonReport)
       yield * self.cucumberApi.createCucumberHtmlReport(options)
+      yield * self.cucumberApi.createCucumberJunitReport(options)
     })
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "co": "^4.6.0",
     "glob": "^7.1.0",
+    "junit-report-builder": "^1.1.1",
     "lodash": "^4.16.3",
     "mkdirp": "^0.5.1",
     "open": "^0.0.5",


### PR DESCRIPTION
Hey this adds another logger which allows junit xml output.

The reasoning behind this is actually pretty simple, as some build systems do not allow for parsing cucumber json results.