### PR TITLE
Update peer-utils.js

### DIFF
--- a/lib/peer-utils.js
+++ b/lib/peer-utils.js
@@ -35,7 +35,7 @@ function getPeerDependency (packageName) {
   }
 
   if (packagePath) {
-    packagePath = packagePath.replace(/node_modules.*?$/, path.join('node_modules', packageName))
+    packagePath = packagePath.replace(/node_modules(?!.*node_modules).*?$/, path.join('node_modules', packageName))
   }
 
   return { version, path: packagePath }


### PR DESCRIPTION
I'm proposing this file change to fix a problem that I've been having. 

I have a peculiar setup for which `getPeerDependency('cucumber')` should return something like this:

`C:\MyProject\node_modules\my-private-module\node_modules\cucumber`

Instead the function is returning

`C:\MyProject\node_modules\cucumber`

This is because the regexp truncates packagePath at the first occurrence of node_modules that it finds, instead I think it should truncate starting from the last occurrence that it finds.

Let me know if this doesn't make sense, if so I will try and reproduce the problem.