### PR TITLE
Fix escaping in html templates

### DIFF
--- a/resources/features.tmpl
+++ b/resources/features.tmpl
@@ -9,7 +9,7 @@
           <a data-toggle="collapse" href="#collapseFeature<%= featureIndex %>">
             <i class="glyphicon glyphicon-chevron-right"></i>
             <i class="glyphicon glyphicon-chevron-down"></i>
-            <b><%= feature.keyword %>:</b><%= feature.name %>
+            <b><%= feature.keyword %>:</b><%- feature.name %>
             <span class="label-container">
               <% if (feature.passed) { %><span class="label label-success"><%= feature.passed %></span><% } %>
               <% if (feature.failed) { %><span class="label label-danger"><%= feature.failed %></span><% } %>
@@ -28,7 +28,7 @@
                   <a data-toggle="collapse" href="#collapseScenario<%= featureIndex %><%=scenarioIndex %>">
                     <i class="glyphicon glyphicon-chevron-right"></i>
                     <i class="glyphicon glyphicon-chevron-down"></i>
-                    <b><%= element.keyword %>:</b><%= element.name %>
+                    <b><%= element.keyword %>:</b><%- element.name %>
                     <span class="label-container">
                       <% if (element.passed) { %><span class="label label-success" title="Passed"><%= element.passed %></span><% } %>
                       <% if (element.notdefined) { %><span class="label label-info" title="Undefined"><%= element.notdefined %></span><% } %>
@@ -67,7 +67,7 @@ this.Then(/^<%= step.name.replace(/"[^"]*"/g, '"\(\[\^\"\]\*\)"') %>$/, function
                         <a href="#error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" data-toggle="collapse">+ Show Error</a>
                         <div id="error<%= featureIndex %><%= scenarioIndex %><%= stepIndex %>" class="panel-collapse collapse">
                           <div class="panel-body">
-                            <pre><%= step.result.error_message %></pre>
+                            <pre><%- step.result.error_message %></pre>
                           </div>
                         </div>
                       <% } %>

--- a/resources/index.tmpl
+++ b/resources/index.tmpl
@@ -14,7 +14,7 @@
       <div class="container">
         <div class="navbar-header">
           <a class="navbar-brand" href="#">Cucumberjs Report</a>
-          <div class="project-name visible-md visible-lg"><%= suite.name %></div>
+          <div class="project-name visible-md visible-lg"><%- suite.name %></div>
           <div class="label-container">
             <span class="label label-success">Passed: <%= suite.passed %></span>
             <span class="label label-danger">Failed: <%= suite.failed %></span>
@@ -46,7 +46,7 @@
           <div id="logOutput" class="panel-collapse collapse">
             <div class="panel-body">
               <pre>
-                   <%= suite.logOutput %>
+                   <%- suite.logOutput %>
               </pre>
             </div>
           </div>


### PR DESCRIPTION
We ran into the problem, that xpath selectors disappeared in the HTML output.
You can see the problem here:
https://jsfiddle.net/dyekx1nj/1/

Apparently lodash supports [different delimiters](https://lodash.com/docs/4.17.2#template)

- `<%=`: interpolates the data simply
- `<%-`: interpolates the data and escapes html (things like `<, >`, probably uses the [`_.escape`](https://lodash.com/docs/4.17.2#escape) function internally)

This pull request fixes the escaping of console outputs and scenario/feature/step names.