### PR TITLE
Fix #137, code cleanup.

### DIFF
--- a/lib/nightwatch-api.js
+++ b/lib/nightwatch-api.js
@@ -86,7 +86,7 @@ module.exports = class NightwatchApi {
   }
 
   /**
-   * @return {void}
+   * @returns {void}
    */
   overrideOriginalSourceGetter (convert) {
     const self = this

--- a/lib/nightwatch-api.js
+++ b/lib/nightwatch-api.js
@@ -6,13 +6,13 @@ const fs = pify(require('fs'), { include: ['readFile'] })
 const cloneDeep = require('lodash.clonedeep')
 const hookUtils = require('./hook-utils')
 const Nightwatch = {
-  Runner: require.main.require('nightwatch/lib/runner/run'),
-  ClientManager: require.main.require('nightwatch/lib/runner/clientmanager'),
-  ClientRunner: require.main.require('nightwatch/lib/runner/cli/clirunner'),
-  ChildProcess: require.main.require('nightwatch/lib/runner/cli/child-process'),
-  Utils: require.main.require('nightwatch/lib/util/utils'),
-  Protocol: require.main.require('nightwatch/lib/api/protocol'),
-  ErrorHandler: require.main.require('nightwatch/lib/runner/cli/errorhandler')
+  Runner: require('nightwatch/lib/runner/run'),
+  ClientManager: require('nightwatch/lib/runner/clientmanager'),
+  ClientRunner: require('nightwatch/lib/runner/cli/clirunner'),
+  ChildProcess: require('nightwatch/lib/runner/cli/child-process'),
+  Utils: require('nightwatch/lib/util/utils'),
+  Protocol: require('nightwatch/lib/api/protocol'),
+  ErrorHandler: require('nightwatch/lib/runner/cli/errorhandler')
 }
 
 process.on('unhandledRejection', (reason, p) => {
@@ -81,6 +81,14 @@ module.exports = class NightwatchApi {
   }
 
   addPathConverter (convert, revert) {
+    this.overrideOriginalSourceGetter(convert)
+    this.addHookTests(revert)
+  }
+
+  /**
+   * @return {void}
+   */
+  overrideOriginalSourceGetter (convert) {
     const self = this
     const originalClientRunnerGetTestSource = Nightwatch.ClientRunner.prototype.getTestSource
 
@@ -109,7 +117,9 @@ module.exports = class NightwatchApi {
       this.settings.src_folders = this.settings.src_folders || []
       return Nightwatch.ClientRunner.prototype.getTestSource.apply(this, arguments)
     }
+  }
 
+  addHookTests (revert) {
     hookUtils.addHookBefore(Nightwatch.ChildProcess.prototype, 'getArgs', function () {
       if (this.args.indexOf('--test') === -1) return
 
@@ -192,7 +202,11 @@ module.exports = class NightwatchApi {
     }
   }
 
-  addTestRunner (run) {
+  /**
+   * @param testRunner{testRunnerCallback}
+   * @returns {void}
+   */
+  addTestRunner (testRunner) {
     const self = this
     const originalRunnerRun = Nightwatch.Runner.prototype.run
 
@@ -221,7 +235,7 @@ module.exports = class NightwatchApi {
             }).then(resolve, reject)
         })
         self._startSession(this.options)
-        executionSuccess = yield * run(modules)
+        executionSuccess = yield * testRunner(modules)
       } catch (err) {
         error = err
       }
@@ -258,4 +272,21 @@ module.exports = class NightwatchApi {
       return originalRunnerRun.apply(this, arguments)
     })
   }
+
+  /**
+   * @returns {void}
+   */
+  overrideOriginalStartTestWorkers () {
+    const originalStartTestWorkers = Nightwatch.ClientRunner.prototype.startTestWorkers
+
+    Nightwatch.ClientRunner.prototype.startTestWorkers = function () {
+      this.test_settings.tag_filter = undefined
+      return originalStartTestWorkers.apply(this, arguments)
+    }
+  }
 }
+
+/**
+ * @callback testRunnerCallback
+ * @param testModules {function (Array<number>)}
+ */

--- a/lib/peer-utils.js
+++ b/lib/peer-utils.js
@@ -44,7 +44,7 @@ function getPeerDependency (packageName) {
 /**
  * @param packageName {string}: Package name to check version.
  * @param ranges {{versionKey: string, callback: function}}
- * @return {*}
+ * @returns {*}
  */
 function checkDependency (packageName, ranges) {
   var found = false

--- a/lib/peer-utils.js
+++ b/lib/peer-utils.js
@@ -41,6 +41,11 @@ function getPeerDependency (packageName) {
   return { version, path: packagePath }
 }
 
+/**
+ * @param packageName {string}: Package name to check version.
+ * @param ranges {{versionKey: string, callback: function}}
+ * @return {*}
+ */
 function checkDependency (packageName, ranges) {
   var found = false
   var version = getPeerDependency(packageName).version

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -73,6 +73,9 @@ module.exports = class Runner {
     return `${rest}-${index}${ext}`
   }
 
+  /**
+   * @param dummyTestModules {Array<string>}
+   */
   * executeTestModules (dummyTestModules) {
     this.options.featureFiles = dummyTestModules.map((dummyTestModule) => this.dummyPathToFeaturePath(dummyTestModule))
     this.options.tags = this.getTags(this.nightwatchApi.nightwatchArgv).concat(this.getSkipTags(this.nightwatchApi.nightwatchArgv))
@@ -108,6 +111,7 @@ module.exports = class Runner {
     this.nightwatchApi.enableShutdownForcing()
     this.nightwatchApi.addTestModulePaths(dummyPaths)
     this.nightwatchApi.addPathConverter(this.featurePathToDummyPath.bind(this), this.dummyPathToFeaturePath.bind(this))
+    this.nightwatchApi.overrideOriginalStartTestWorkers()
     this.nightwatchApi.addTestRunner(this.executeTestModules.bind(this))
     this.nightwatchApi.addHookAfterChildProcesses(function * () {
       const reports = yield pify(glob)(self.addIndexToFileName(self.options.jsonReport, '*'))

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nightwatch-cucumber",
   "description": "Nightwatch.js plugin for Cucumber.js",
   "main": "lib/index.js",
-  "version": 6.1.2,
+  "version": "6.1.2",
   "engines": {
     "node": ">= 4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "nightwatch-cucumber",
   "description": "Nightwatch.js plugin for Cucumber.js",
   "main": "lib/index.js",
+  "version": 6.1.2,
   "engines": {
     "node": ">= 4.0.0"
   },


### PR DESCRIPTION
**Remove main.require.** It only adds complexity when developing locally and debugging several packages at the same time. But global nightwatch probably won't work, need to use ./node_modules nightwatch. This is up to you, you can skip this change I guess...

**Add some jsdoc typing to some methods**

**Fixes** #137 . Nightwatch.walk was called with wrong params (tag_filter) when starting workers. method ClientRunner.startTestWorkers overrided.

**Added version to package.json** This is needed only if you want to allow installing from github on npm.