### PR TITLE
fix: add support for child page objects

### DIFF
--- a/lib/nightwatch-api.js
+++ b/lib/nightwatch-api.js
@@ -73,18 +73,26 @@ module.exports = class NightwatchApi {
     }
   }
 
-  promisifyPageObjects (api) {
+  _promisifyChildPageObjects (page) {
     const self = this
-    if (api.page) {
-      Object.keys(api.page).forEach((key) => {
-        const originalPageCreator = api.page[key]
-        api.page[key] = function () {
+    Object.keys(page).forEach((key) => {
+      if (typeof page[key] !== 'function') {
+        this._promisifyChildPageObjects(page[key])
+      } else {
+        const originalPageCreator = page[key]
+        page[key] = function () {
           const page = originalPageCreator()
           self.promisifyApi(page)
           self.promisifyExpect(page)
           return page
         }
-      })
+      }
+    })
+  }
+
+  promisifyPageObjects (api) {
+    if (api.page) {
+      return this._promisifyChildPageObjects(api.page)
     }
   }
 


### PR DESCRIPTION
For subdirectories feature in nightwatch please check https://github.com/nightwatchjs/nightwatch/pull/902

This pull request is to update the `promisifyPageObjects()` to take care about the subdirectories.

I only test it manually so I hope i can get some help to write some automatic test case if possible.