### PR TITLE
Support of Cucumber CLI boolean arguments

### DIFF
--- a/examples/create-examples.js
+++ b/examples/create-examples.js
@@ -13,7 +13,8 @@ const examples = {
   programmatical,
   simple,
   tag,
-  babel
+  babel,
+  pendingWithNoStrict
 }
 
 function background () {
@@ -403,6 +404,28 @@ function babel () {
     .and('the Yahoo search form exists', `async () => {
       await client.assert.visible('input[name="p"]')
     }`)
+}
+
+function pendingWithNoStrict () {
+  return testCaseFactory
+    .create('pending-with-no-strict-example', { cucumberArgs: ['--no-strict'] })
+    .feature('Google Search')
+    .scenario('Searching Google')
+    .given('I open Google`s search page', () => {
+      return client
+        .url('http://google.com')
+        .waitForElementVisible('body', 1000)
+    })
+    .then('the title is "Google"', (text) => {
+      return 'pending'
+    })
+    .and('the Google search form exists', () => {
+      return client.assert.visible('input[name="q"]')
+    })
+    .scenario('Searching Google again')
+    .given('I open Google`s search page')
+    .then('the title is "Google"')
+    .and('the Google search form exists')
 }
 
 Object.keys(examples).forEach((name) => {

--- a/examples/pending-with-no-strict-example/features/google-search.feature
+++ b/examples/pending-with-no-strict-example/features/google-search.feature
@@ -1,0 +1,13 @@
+Feature: Google Search
+
+Scenario: Searching Google
+
+  Given I open Google`s search page
+  Then the title is "Google"
+  And the Google search form exists
+
+Scenario: Searching Google again
+
+  Given I open Google`s search page
+  Then the title is "Google"
+  And the Google search form exists

--- a/examples/pending-with-no-strict-example/features/step_definitions/steps.js
+++ b/examples/pending-with-no-strict-example/features/step_definitions/steps.js
@@ -1,0 +1,18 @@
+const { client } = require('nightwatch-cucumber')
+const { defineSupportCode } = require('cucumber')
+
+defineSupportCode(({ Given, Then, When }) => {
+  Given(/^I open Google`s search page$/, () => {
+    return client
+      .url('http://google.com')
+      .waitForElementVisible('body', 1000)
+  })
+
+  Then(/^the title is "(.*?)"$/, (text) => {
+    return 'pending'
+  })
+
+  Then(/^the Google search form exists$/, () => {
+    return client.assert.visible('input[name="q"]')
+  })
+})

--- a/examples/pending-with-no-strict-example/nightwatch.conf.js
+++ b/examples/pending-with-no-strict-example/nightwatch.conf.js
@@ -1,0 +1,53 @@
+const seleniumServer = require('selenium-server')
+const phantomjs = require('phantomjs-prebuilt')
+const chromedriver = require('chromedriver')
+
+require('nightwatch-cucumber')({
+  cucumberArgs: ['--require', 'timeout.js', '--require', 'features/step_definitions', '--no-strict', 'features']
+})
+
+module.exports = {
+  output_folder: 'reports',
+  custom_assertions_path: '',
+  live_output: false,
+  disable_colors: false,
+  selenium: {
+    start_process: true,
+    server_path: seleniumServer.path,
+    log_path: '',
+    host: '127.0.0.1',
+    port: 4444
+  },
+  test_settings: {
+    default: {
+      launch_url: 'http://localhost:8087',
+      selenium_port: 4444,
+      selenium_host: '127.0.0.1',
+      desiredCapabilities: {
+        browserName: 'phantomjs',
+        javascriptEnabled: true,
+        acceptSslCerts: true,
+        'phantomjs.binary.path': phantomjs.path
+      }
+    },
+    chrome: {
+      desiredCapabilities: {
+        browserName: 'chrome',
+        javascriptEnabled: true,
+        acceptSslCerts: true
+      },
+      selenium: {
+        cli_args: {
+          'webdriver.chrome.driver': chromedriver.path
+        }
+      }
+    },
+    firefox: {
+      desiredCapabilities: {
+        browserName: 'firefox',
+        javascriptEnabled: true,
+        acceptSslCerts: true
+      }
+    }
+  }
+}

--- a/examples/pending-with-no-strict-example/timeout.js
+++ b/examples/pending-with-no-strict-example/timeout.js
@@ -1,0 +1,5 @@
+const {defineSupportCode} = require('cucumber')
+
+defineSupportCode(({setDefaultTimeout}) => {
+  setDefaultTimeout(30 * 1000)
+})

--- a/lib/cucumber-api.js
+++ b/lib/cucumber-api.js
@@ -97,12 +97,17 @@ module.exports = class CucumberAPI {
     }
   }
 
+  isBooleanArg (args, index) {
+    const nextIndex = index + 1
+    return args[nextIndex].startsWith('--') || nextIndex === args.length - 1
+  }
+
   getFeatureFiles (args) {
     const featureFiles = []
     let i = 0
     while (i < args.length) {
       if (args[i].startsWith('--')) {
-        i += 2
+        i += this.isBooleanArg(args, i) ? 1 : 2
       } else {
         featureFiles.push(args[i])
         i++
@@ -121,8 +126,12 @@ module.exports = class CucumberAPI {
         i += 2
       } else if (args[i].startsWith('--')) {
         result.push(args[i])
-        result.push(args[i + 1])
-        i += 2
+        if (this.isBooleanArg(args, i)) {
+          i++
+        } else {
+          result.push(args[i + 1])
+          i += 2
+        }
       } else {
         i++
       }

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -28,4 +28,19 @@ describe('Config', () => {
         result.output.should.contain('..........')
       })
   })
+
+  it('should exit with success status if pending step exists and --no-strict is passed as cucumber CLI argument', () => {
+    return testCaseFactory
+      .create('config-cucumber-no-strict-arg-test', {
+        cucumberArgs: ['--no-strict']
+      })
+      .feature('addition')
+      .scenario('small numbers')
+      .given('User is on the simple calculator page', () => client.init())
+      .and('User enter 4 in A field', () => 'pending')
+      .run()
+      .then((result) => {
+        result.exitCode.should.equal(0)
+      })
+  })
 })


### PR DESCRIPTION
I needed to skip some tests dynamically based on the browser and the only option I found is by returning 'pending' in `Before` hook. But then the whole test suite fails returning exit code 1. In order to avoid failure, option `--no-strict` could be used. Unfortunately, current version of nightwatch-cucumber expects that every parameter has an argument.

As a workaround, I could pass `--no-strict` twice in cucumberArgs, but this change fixes the issue. 