### PR TITLE
feat: Optionally treat failed scenarios as non-error events

### DIFF
--- a/lib/nightwatch-api.js
+++ b/lib/nightwatch-api.js
@@ -330,8 +330,12 @@ module.exports = class NightwatchApi {
       this.additionalOpts = originalAdditionalOpts
       this.options = originalOptions
 
+      if (originalAdditionalOpts.end_session_on_fail) {
+        error = error || !executionSuccess
+      }
+
       if (!originalAdditionalOpts.src_folders || !originalAdditionalOpts.src_folders.length || error || !executionSuccess) {
-        return this.doneCb(error || !executionSuccess, {})
+        return this.doneCb(error, {})
       }
 
       return originalRunnerRun.apply(this, arguments)


### PR DESCRIPTION
Only reports true errors to `this.doneCb` to prevent failed scenarios from triggering severe side-effects.