### PR TITLE
Allow array for skip tag

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -27,24 +27,18 @@ module.exports = class Runner {
     })
   }
 
-  getTags (nightwatchArgv) {
-    let result = nightwatchArgv.tag || []
+  getTags (tags) {
+    tags = tags || []
 
-    if (typeof result === 'string') {
-      result = result.split(',')
+    if (typeof tags === 'string') {
+      tags = tags.split(',')
     }
 
-    return result.map((tag) => `@${tag}`)
-  }
-
-  getSkipTags (nightwatchArgv) {
-    let result = nightwatchArgv.skiptags || []
-
-    if (typeof result === 'string') {
-      result = result.split(',')
+    if (Array.isArray(tags)) {
+      return tags.map((tag) => `@${tag}`)
+    } else {
+      throw new Error(`Expected tags to be Array or String.`)
     }
-
-    return result.map((tag) => `@${tag}`)
   }
 
   featurePathToDummyPath (featureFile) {
@@ -85,8 +79,8 @@ module.exports = class Runner {
       args: this.options.cucumberArgs,
       featureFiles,
       jsonReport: this.jsonReport,
-      tags: this.getTags(this.nightwatchApi.nightwatchArgv),
-      skipTags: this.getSkipTags(this.nightwatchApi.nightwatchArgv)
+      tags: this.getTags(this.nightwatchApi.nightwatchArgv.tag),
+      skipTags: this.getTags(this.nightwatchApi.nightwatchArgv.skiptags)
     })
     return yield * this.cucumberApi.run(cucumberArgs)
   }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -31,16 +31,20 @@ module.exports = class Runner {
     let result = nightwatchArgv.tag || []
 
     if (typeof result === 'string') {
-      result = [result]
+      result = result.split(',')
     }
 
     return result.map((tag) => `@${tag}`)
   }
 
   getSkipTags (nightwatchArgv) {
-    if (!nightwatchArgv.skiptags) return []
+    let result = nightwatchArgv.skiptags || []
 
-    return nightwatchArgv.skiptags.split(',').map((tag) => `@${tag}`)
+    if (typeof result === 'string') {
+      result = result.split(',')
+    }
+
+    return result.map((tag) => `@${tag}`)
   }
 
   featurePathToDummyPath (featureFile) {


### PR DESCRIPTION
I noticed passing an array into skiptags using the programmatic API caused issues. Small fix to allow arrays in skip tags.

`getSkipTags` and `getTags` are now the same except for the key that they are looking at in argv. I'd be willing to combine those into a single function if you think that makes sense.