### PR TITLE
Allow for single features to be added to cucumberargs

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -15,20 +15,58 @@ module.exports = class Runner {
     this.originalFeaturePath = {}
   }
 
-  generateDummyTestModules () {
-    this.featureFiles.forEach((featureSource) => {
-      let featureFiles
-      if (fs.statSync(featureSource).isDirectory()) {
-        featureFiles = glob.sync(path.join(featureSource, '**/*.feature'))
-      } else {
-        featureFiles = [featureSource]
-      }
+  getSourceFile (featureSource) {
+    if (featureSource.startsWith('@')) {
+      return featureSource.substr(1, featureSource.length - 1)
+    }
+    return featureSource
+  }
 
-      featureFiles.forEach((featureFile) => {
-        const dummyTestModuleFile = this.featurePathToDummyPath(featureFile)
-        mkdirp.sync(path.dirname(dummyTestModuleFile))
-        fs.writeFileSync(dummyTestModuleFile, '')
+  getFeatureFilesFromRerunFile (rerunFile) {
+    const data = fs.readFileSync(this.getSourceFile(rerunFile))
+    return data.toString()
+      .split('\n')
+      .map(featurePath => featurePath.trim().replace(/(:\d*)/g, ''))
+      // filter empty paths
+      .filter(featurePath => featurePath)
+  }
+
+  getFeatureDirectories () {
+    return this.featureFiles
+      .map(featureSource => {
+        if (featureSource.startsWith('@')) {
+          return this.getFeatureFilesFromRerunFile(featureSource)
+            .map(featurePath => path.dirname(featurePath))
+        } else if (fs.statSync(featureSource).isDirectory()) {
+          return featureSource
+        }
+        return path.dirname(featureSource)
       })
+      // flatten
+      .reduce((paths, currentPaths) => paths.concat(currentPaths), [])
+  }
+
+  getFeatureFiles () {
+    return this.featureFiles
+      .map(featureSource => {
+        if (featureSource.startsWith('@')) {
+          return this.getFeatureFilesFromRerunFile(featureSource)
+        } else if (fs.statSync(featureSource).isDirectory()) {
+          return glob.sync(path.join(featureSource, '**/*.feature'))
+        }
+        return [featureSource]
+      })
+      // flatten
+      .reduce((paths, currentPaths) => paths.concat(currentPaths), [])
+      // make unique list
+      .filter((featureFilePath, idx, paths) => paths.indexOf(featureFilePath === idx))
+  }
+
+  generateDummyTestModules () {
+    this.getFeatureFiles().forEach((featureFile) => {
+      const dummyTestModuleFile = this.featurePathToDummyPath(featureFile)
+      mkdirp.sync(path.dirname(dummyTestModuleFile))
+      fs.writeFileSync(dummyTestModuleFile, '')
     })
   }
 
@@ -97,18 +135,17 @@ module.exports = class Runner {
     this.cucumberApi = new CucumberApi(options)
     this.jsonReport = this.cucumberApi.getJSONReportName(options.cucumberArgs)
     this.featureFiles = this.cucumberApi.getFeatureFiles(options.cucumberArgs)
-    this.featureFiles.forEach((featureSource) => {
-      try {
-        fs.statSync(featureSource)
-      } catch (err) {
-        throw new Error(`Feature source ${featureSource} doesn't exists`)
-      }
-    })
+    this.featureFiles
+      .map(this.getSourceFile)
+      .forEach((featureSource) => {
+        try {
+          fs.statSync(featureSource)
+        } catch (err) {
+          throw new Error(`Feature source ${featureSource} doesn't exists`)
+        }
+      })
 
-    const dummyPaths = this.featureFiles.map((srcPath) => {
-      const sourcePath = fs.statSync(srcPath).isDirectory() ? srcPath : path.dirname(srcPath)
-      return path.join(dummyTestModulesFolder, sourcePath)
-    })
+    const dummyPaths = this.getFeatureDirectories().map(srcPath => path.join(dummyTestModulesFolder, srcPath))
 
     this.generateDummyTestModules()
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -17,7 +17,12 @@ module.exports = class Runner {
 
   generateDummyTestModules () {
     this.featureFiles.forEach((featureSource) => {
-      const featureFiles = glob.sync(path.join(featureSource, '**/*.feature'))
+      let featureFiles
+      if (fs.statSync(featureSource).isDirectory()) {
+        featureFiles = glob.sync(path.join(featureSource, '**/*.feature'))
+      } else {
+        featureFiles = [featureSource]
+      }
 
       featureFiles.forEach((featureFile) => {
         const dummyTestModuleFile = this.featurePathToDummyPath(featureFile)
@@ -99,7 +104,11 @@ module.exports = class Runner {
         throw new Error(`Feature source ${featureSource} doesn't exists`)
       }
     })
-    const dummyPaths = this.featureFiles.map((srcPath) => path.join(dummyTestModulesFolder, srcPath))
+
+    const dummyPaths = this.featureFiles.map((srcPath) => {
+      const sourcePath = fs.statSync(srcPath).isDirectory() ? srcPath : path.dirname(srcPath)
+      return path.join(dummyTestModulesFolder, sourcePath)
+    })
 
     this.generateDummyTestModules()
 


### PR DESCRIPTION
This PR allows to add single feature files in addition to or instead of feature file folders.

Example:
```js
// nightwatch.conf.js

require('nightwatch-cucumber')({
  cucumberArgs: [
    '--require', 'hooks.js',
    '--require', 'features/step_definitions',
    '--format', 'json:reports/cucumber.json',
    '--format-options', '{"colorsEnabled":false}',
    'features/just_run_this.feature'
  ]
})

module.exports = {
  ...
}
```