### PR TITLE
Update cucumber-api.js

### DIFF
--- a/lib/cucumber-api.js
+++ b/lib/cucumber-api.js
@@ -156,9 +156,11 @@ module.exports = class CucumberAPI {
   * mergeCucumberJsonReports (reports, target) {
     let sumReport = []
     for (let i = 0; i < reports.length; i++) {
-      const report = JSON.parse(yield fs.readFile(reports[i]))
-      sumReport = sumReport.concat(report)
-      yield fs.unlink(reports[i])
+      try {
+        const report = JSON.parse(yield fs.readFile(reports[i]))
+        sumReport = sumReport.concat(report)
+        yield fs.unlink(reports[i])
+      } catch(e) {}
     }
     yield fs.writeFile(target, JSON.stringify(sumReport, null, 2))
   }


### PR DESCRIPTION
Add try catch for empty report.
We Caught this bad problem many times. This fix has helped.
```
UnhandledRejection Handled
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at CucumberAPI.mergeCucumberJsonReports (/var/lib/jenkins/workspace/PROFI-autotest-desktop-DONTUSE/warp/node_modules/nightwatch-cucumber/lib/cucumber-api.js:152:27)
```