### PR TITLE
Enforce relative paths for features. Resolves #326

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -167,6 +167,11 @@ module.exports = class Runner {
         }
       })
 
+    // enforce relative paths so path.join() works on Windows
+    this.featureFiles = this.featureFiles.map((currentPath) => {
+      return path.isAbsolute(currentPath) ? path.relative(process.cwd(), currentPath) : currentPath
+    })
+
     const dummyPaths = this.getFeatureDirectories().map(srcPath => path.join(dummyTestModulesFolder, srcPath))
 
     this.generateDummyTestModules()


### PR DESCRIPTION
Passing absolute paths in Windows for feature directories, breaks `nightwatch-cucumber` because `path.join` does not work correctly (more information in #326)

The change converts all feature paths to relative to the current process directory.