### PR TITLE
Give sections a link back to the nightwatch-cucumber api

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ function getClientProxy (subPages) {
 module.exports.client = getClientProxy([])
 
 module.exports.Section = function Section (options) {
-  const section = VanillaSection(options)
+  const section = new VanillaSection(options)
   runner.nightwatchApi.promisifySection(section)
   return section
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+const VanillaSection = require('nightwatch/lib/page-object/section')
 let runner
 
 module.exports = function (providedOptions) {
@@ -42,3 +43,9 @@ function getClientProxy (subPages) {
 }
 
 module.exports.client = getClientProxy([])
+
+module.exports.Section = function Section (options) {
+  const section = VanillaSection(options)
+  runner.nightwatchApi.promisifySection(section)
+  return section
+}


### PR DESCRIPTION
This PR allows for the dynamic creation of nightwatch `Section`s (either from commands or otherwise). Without this reference any Sections created by the user are not tied into nightwatch-cucumber's promises and runtime.

Now possible:
```javascript
// some-page-object.js
const Section = require('nightwatch/lib/page-object/section');

module.exports = {
  commands: [{
    getScalarSection: function getScalarSection(metric) {
      const selector = `//div[contains(@class, "scalar-container")]//h6[contains(text(), "${metric}")]/..`;
      const props = {
        name: `Scalar - ${metric}`,
        parent: this,
        selector,
        locateStrategy: 'xpath',
        elements: {
          title: {
            selector: `${selector}/h6`,
            locateStrategy: 'xpath'
          },
          value: {
            selector: `${selector}/h1/*`,
            locateStrategy: 'xpath'
          }
        }
      };
      const section = new Section(props);
      this.__nwc.promisifySection(section);
      return section;
    }
  }]
}
```