### PR TITLE
fix referencing sections

### DIFF
--- a/lib/nightwatch-api.js
+++ b/lib/nightwatch-api.js
@@ -66,13 +66,15 @@ module.exports = class NightwatchApi {
   promisifyExpect (api) {
     const self = this
     if (!api.expect) return
-    const originalExpectElement = api.expect.element
+    [ 'element', 'section' ].forEach(field => {
+      const originalExpectation = api.expect[field]
 
-    api.expect.element = function () {
-      const result = originalExpectElement.apply(this, arguments)
-      self.promisifyApi(result)
-      return result
-    }
+      api.expect[field] = function () {
+        const result = originalExpectation.apply(this, arguments)
+        self.promisifyApi(result)
+        return result
+      }
+    })
   }
 
   promisifySection (section) {


### PR DESCRIPTION
## Symptoms
Given a page object defined as
```
module.exports = {
	url: url('/page1'),
	sections: {
		heading: {
			selector: '#heading',
		}
	}
};
```

The following both succeeded.
```
client.expect.section('@heading').to.be.visible;
client.expect.section('@heading').to.not.be.visible;
```
## Solution
With the fix if the `#heading` element is visible within the page
```
client.expect.section('@heading').to.be.visible;
```
passes, whereas
```
client.expect.section('@heading').to.not.be.visible;
```
fails.