### PR TITLE
Proxy the newly wrapped Section to maintain inheritance

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,4 +48,3 @@ module.exports.Section = new Proxy(function () {}, {
     return new runner.nightwatchApi.Section(...args)
   }
 })
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,9 @@ function getClientProxy (subPages) {
 
 module.exports.client = getClientProxy([])
 
-module.exports.Section = function () {
-  return runner.nightwatchApi.Section.apply(this, arguments)
-}
+module.exports.Section = new Proxy(function () {}, {
+  construct (target, args) {
+    return new runner.nightwatchApi.Section(...args)
+  }
+})
+

--- a/lib/nightwatch-api.js
+++ b/lib/nightwatch-api.js
@@ -1,4 +1,3 @@
-const util = require('util')
 const co = require('co')
 const pify = require('pify')
 const fs = pify(require('fs'), { include: ['readFile'] })
@@ -25,11 +24,11 @@ module.exports = class NightwatchApi {
     this.options = options
     this.colorsEnabled = colorsEnabled
     const self = this
-    this.Section = function () {
-      Nightwatch.Section.apply(this, arguments)
-      self.promisifySection(this)
-    }
-    util.inherits(this.Section, Nightwatch.Section)
+    this.Section = class PromisedSection extends Nightwatch.Section {
+      constructor() {
+        super(...arguments);
+        self.promisifySection(this)
+      }
   }
 
   _startSession (options) {

--- a/lib/nightwatch-api.js
+++ b/lib/nightwatch-api.js
@@ -26,7 +26,7 @@ module.exports = class NightwatchApi {
     const self = this
     this.Section = class PromisedSection extends Nightwatch.Section {
       constructor () {
-        super(...arguments);
+        super(...arguments)
         self.promisifySection(this)
       }
     }

--- a/lib/nightwatch-api.js
+++ b/lib/nightwatch-api.js
@@ -25,10 +25,11 @@ module.exports = class NightwatchApi {
     this.colorsEnabled = colorsEnabled
     const self = this
     this.Section = class PromisedSection extends Nightwatch.Section {
-      constructor() {
+      constructor () {
         super(...arguments);
         self.promisifySection(this)
       }
+    }
   }
 
   _startSession (options) {

--- a/test/page-objects.test.js
+++ b/test/page-objects.test.js
@@ -218,4 +218,43 @@ describe('Assertion features', () => {
         result.features[0].scenarios[0].result.stepCounts.should.deep.equal({passed: 3})
       })
   })
+
+  it('should export a section that inherits correctly', () => {
+    return testCaseFactory
+      .create('section-interface-test')
+      .pageObject('calculator', `
+      const { Section } = require('../../../lib/index')
+      const commands = {
+        getDynamicSection() {
+          return new Section({
+            name: 'Dynamic Section',
+            parent: this,
+            selector: 'body'
+          })
+        }
+      }
+      module.exports = {
+        url: 'http://yahoo.com',
+        elements: {
+          body: 'body',
+          searchBar: 'input[name="p"]'
+        },
+        commands: [commands]
+      }`)
+      .feature('Section')
+      .scenario('toString')
+      .prependStepDefinition(`
+          const calculator = client.page.calculator();
+          const dynamicSection = calculator.getDynamicSection();
+      `)
+      .then('toString works', () => dynamicSection.assert.equal(dynamicSection.toString(), 'Section[name=Dynamic Section]'))
+      .then('parent is set', () => dynamicSection.assert.equal(dynamicSection.parent, calculator))
+      .run()
+      .then((result) => {
+        result.features[0].result.status.should.be.passed
+        result.features[0].result.scenarioCounts.should.deep.equal({passed: 1})
+        result.features[0].scenarios[0].result.status.should.be.passed
+        result.features[0].scenarios[0].result.stepCounts.should.deep.equal({passed: 2})
+      })
+  })
 })


### PR DESCRIPTION
By exporting `Section = new Proxy` we maintain the inheritance that is configured by the `NightwatchApi` class. This is important for operability since the `toString` of Nightwatch's `Section` object is overridden.

```js
const { Section } = require('nightwatch-cucumber')
console.log(new Section({ name: 'Foo' })
```

Old behavior:
```
[Object object]
```

New behavior
```
Section[name=Foo]
```

Closes #350