### PR TITLE
Custom json formatters that pass file location of formatter do not wo…

### DIFF
--- a/lib/cucumber-api.js
+++ b/lib/cucumber-api.js
@@ -83,13 +83,13 @@ module.exports = class CucumberAPI {
   }
 
   getJSONReportName (args) {
-    const pattern = /^json:(.*)$/
+    const pattern = /^(.*)json:(.*)$/
     let i = 0
     while (i < args.length - 2 && !(args[i] === '--format' && pattern.test(args[i + 1]))) {
       i++
     }
     if (i < args.length - 2) {
-      return args[i + 1].match(pattern)[1]
+      return args[i + 1].match(pattern)[2]
     }
   }
 


### PR DESCRIPTION
Using a custom json formatter fails when running in parallel mode.  Take the example below:

> {
  cucumberArgs: [
    '--require', 'features/step_definitions',
    '--format', './lib/json:reports/cucumber.json',
    'features'
  ],
  nightwatchOutput: true
}

The getJSONReportName function in ./lib/cucumber-api.js uses a regular the following regular expression to get the JSON reportname:

> const pattern = /^json:(.*)$/

This will not match a formatter that passes the file location of the formatter. I have changed the regular expression to:

> const pattern = /^(.*)json:(.*)$/

It will now match a file as long as the file with its path as long as the filename is still 'json'.

This should resolve:  #374 
